### PR TITLE
Added check for iframe context

### DIFF
--- a/Assets/ArcadeKeyBinding/lib/ArcadeDetector.jslib
+++ b/Assets/ArcadeKeyBinding/lib/ArcadeDetector.jslib
@@ -1,6 +1,6 @@
 
 mergeInto(LibraryManager.library, {
   CheckIsArcadeMachine: function () {
-    return isArcadeMachine == true;
+    return (globalThis.isArcadeMachine == true) || (parent.isArcadeMachine == true);
   },
 });


### PR DESCRIPTION
Checks for both `globalThis.isArcadeMachine` and `parent.isArcadeMachine`. One of these must be true for it to determine it is on the arcade machine.